### PR TITLE
Fixing sticky navigation at mobile

### DIFF
--- a/lib/_stylesheets/custom.scss
+++ b/lib/_stylesheets/custom.scss
@@ -8,9 +8,18 @@ a, p, div, span {
 }
 
 .sticky-nav {
-  position: sticky;
   overflow: auto;
   top: 40px;
+  margin-bottom: 40px;
+}
+
+@media screen and (min-width: 768px) {
+  .sticky-nav {
+    position: sticky;
+    overflow: auto;
+    top: 40px;
+    margin-bottom: 0px;
+  }
 }
 
 /* links */


### PR DESCRIPTION
Mobile navigation was 'sticky' causing visual bug at mobile of its contents overlapping main content.