### PR TITLE
Amended the header to use the 'organisational' header as opposed to the 'transactional' header as recommended in the NHS Design System

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to NHSBSA Digital Playbook
+# Contributing to NHSBSA Digital, Data and Technology Playbook
 
-NHSBSA Digital Playbook is released under the [Apache 2 license](LICENCE.md). If you would like to contribute
+NHSBSA Digital, Data and Technology Playbook is released under the [Apache 2 license](LICENCE.md). If you would like to contribute
 something, or simply want to hack on the code this document should help you get started.
 
 ## Code of Conduct

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NHSBSA Digital Playbook
+# NHSBSA Digital, Data and Technology Playbook
 
-The NHSBSA Digital Playbook contains documentation on how we work when delivering Digital Services at the [NHS Business Services Authority][nhsbsa_homepage].
+The NHSBSA Digital, Data and Technology Playbook contains documentation on how we work when delivering DDaT Services at the [NHS Business Services Authority][nhsbsa_homepage].
 
 The published playbook is hosted on [Github pages][nhsbsa_digital_playbook]
 

--- a/lib/_layouts/_article.njk
+++ b/lib/_layouts/_article.njk
@@ -14,9 +14,9 @@
       "showSearch": "false",
       "organisation": {
         "name": "Business Services Authority",
-        "split": "Digital Playbook"
+        "split": productShortName
       },
-    "ariaLabel": productName,
+    "ariaLabel": productLongName,
     "containerClasses": "nhsuk-width-container-fluid"
     })
   }}

--- a/lib/_layouts/_article.njk
+++ b/lib/_layouts/_article.njk
@@ -9,16 +9,17 @@
 
 {% block header %}
   {{ appArticleHeader({
-    homeHref: homeUrl,
-    "service": {
-      "name": productName,
-      "href": homeUrl
-    },
-    "showNav": "false",
-    "showSearch": "false",
+      homeHref: homeUrl,
+      "showNav": "false",
+      "showSearch": "false",
+      "organisation": {
+        "name": "Business Services Authority",
+        "split": "Digital Playbook"
+      },
     "ariaLabel": productName,
     "containerClasses": "nhsuk-width-container-fluid"
-  }) }}
+    })
+  }}
 {% endblock %}
 
 {% block content %}

--- a/lib/_layouts/_base.njk
+++ b/lib/_layouts/_base.njk
@@ -2,8 +2,6 @@
 
 {% set htmlClasses = 'no-js' %}
 {% set homeUrl = '/' | url %}
-{% set productLongName = 'NHSBSA Digital, Data and Technology Playbook' %}
-{% set productShortName = 'DDaT Playbook' %}
 
 {% from "header/macro.njk" import header as appHeader %}
 {% from "appArticleHeader/macro.njk" import appArticleHeader %}

--- a/lib/_layouts/_base.njk
+++ b/lib/_layouts/_base.njk
@@ -24,15 +24,16 @@
 
 {% block header %}
   {{ appHeader({
-    homeHref: homeUrl,
-    "service": {
-      "name": productName,
-      "href": homeUrl
-    },
-    "showNav": "false",
-    "showSearch": "false",
-    "ariaLabel": productName
-  }) }}
+      homeHref: homeUrl,
+      "showNav": "false",
+      "showSearch": "false",
+      "organisation": {
+        "name": "Business Services Authority",
+        "split": "Digital Playbook"
+      },
+      "ariaLabel": productName
+    })
+  }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/lib/_layouts/_base.njk
+++ b/lib/_layouts/_base.njk
@@ -2,7 +2,8 @@
 
 {% set htmlClasses = 'no-js' %}
 {% set homeUrl = '/' | url %}
-{% set productName = 'NHSBSA Digital Playbook' %}
+{% set productLongName = 'NHSBSA Digital, Data and Technology Playbook' %}
+{% set productShortName = 'DDaT Playbook' %}
 
 {% from "header/macro.njk" import header as appHeader %}
 {% from "appArticleHeader/macro.njk" import appArticleHeader %}
@@ -19,7 +20,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  {% if title %}{{ title }} - {% endif %} {{ serviceName or productName }} - NHSBSA
+  {% if title %}{{ title }} - {% endif %} {{ serviceName or productLongName }} - NHSBSA
 {% endblock %}
 
 {% block header %}
@@ -29,9 +30,9 @@
       "showSearch": "false",
       "organisation": {
         "name": "Business Services Authority",
-        "split": "Digital Playbook"
+        "split": productShortName
       },
-      "ariaLabel": productName
+      "ariaLabel": productLongName
     })
   }}
 {% endblock %}

--- a/lib/_layouts/_collection.njk
+++ b/lib/_layouts/_collection.njk
@@ -7,8 +7,8 @@
 
 {% block main %}
   {{ hero({
-    heading: "NHSBSA Digital, Data and Technology Playbook",
-    text: "How we design, build and run services at the NHSBSA"
+    heading: heroHeading,
+    text: heroText
   }) }}
 
   <div class="nhsuk-width-container">

--- a/lib/_layouts/_collection.njk
+++ b/lib/_layouts/_collection.njk
@@ -7,7 +7,7 @@
 
 {% block main %}
   {{ hero({
-    heading: "NHSBSA Digital Playbook",
+    heading: "NHSBSA Digital, Data and Technology Playbook",
     text: "How we design, build and run services at the NHSBSA"
   }) }}
 

--- a/lib/_stylesheets/custom.scss
+++ b/lib/_stylesheets/custom.scss
@@ -501,3 +501,9 @@ dd code {
 .hljs.css .hljs-keyword {
 	color: #330072;
 }
+
+/* Header */
+
+.nhsuk-organisation-name-split {
+	font-weight: 200;
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nhsbsa-digital-playbook",
   "version": "1.0.0",
-  "description": "Playbook for NHSBSA Digital projects",
+  "description": "Playbook for NHSBSA Digital, Data and Technology projects",
   "main": "index.js",
   "scripts": {
     "start": "npx @11ty/eleventy --serve --pathprefix 'nhsbsa-digital-playbook'",

--- a/src/_layouts/accessibility.njk
+++ b/src/_layouts/accessibility.njk
@@ -1,1 +1,3 @@
 {% extends "_accessibility.njk" %}
+{% set productLongName = 'NHSBSA Digital, Data and Technology Playbook' %}
+{% set productShortName = 'DDaT Playbook' %}

--- a/src/_layouts/article.njk
+++ b/src/_layouts/article.njk
@@ -1,1 +1,3 @@
 {% extends "_article.njk" %}
+{% set productLongName = 'NHSBSA Digital, Data and Technology Playbook' %}
+{% set productShortName = 'DDaT Playbook' %}

--- a/src/_layouts/collection.njk
+++ b/src/_layouts/collection.njk
@@ -1,1 +1,5 @@
 {% extends "_collection.njk" %}
+{% set productLongName = 'NHSBSA Digital, Data and Technology Playbook' %}
+{% set productShortName = 'DDaT Playbook' %}
+{% set heroHeading = 'NHSBSA Digital, Data and Technology Playbook' %}
+{% set heroText = 'How we design, build and run services at the NHSBSA' %}

--- a/src/index.md
+++ b/src/index.md
@@ -7,7 +7,7 @@ pagination:
   size: 50
   alias: articles
 ---
-This website documents the specific technology, tools and processes that NHS Business Services Authority (NHSBSA) digital delivery teams use to build and operate services.
+This website documents the specific technology, tools and processes that NHS Business Services Authority (NHSBSA) Digital, Data and Technology (DDaT) delivery teams use to build and operate services.
 
 It is intended to complement, not replace, existing UK Government and NHS guidance:
 


### PR DESCRIPTION
## What
Amended the header to use the 'organisational' header as opposed to the 'transactional' header as recommended in the NHS Design System

## Why
Happy to be shot down, but I think the playbook probably needs to use the 'organisational' header as opposed to the 'transactional' header. This PR looks to amend that:

![image](https://user-images.githubusercontent.com/45825845/207641548-333b916e-68de-412e-b07d-b4881def5d18.png)

## Links

https://service-manual.nhs.uk/design-system/components/header#organisational-header