### PR TITLE
fixing broken links

### DIFF
--- a/src/development/coding-secrets-detection.md
+++ b/src/development/coding-secrets-detection.md
@@ -80,10 +80,10 @@ Use secrets detection tools to protect against mistaken commits, and to alert if
 
 To use the NHSBSA Gitleaks definitions:
 
-* Copy the [nhsbsa-gitleaks.toml](https://gitlab.com/nhsbsa/platform-services/gitleaks/nhsbsa-gitleaks/-/raw/main/nhsbsa-gitleaks.toml) config file into your project
+* Copy the [nhsbsa-gitleaks.toml](https://gitlab.com/nhsbsa/platform-services/gitleaks/gitleaks-nhsbsa/-/raw/main/gitleaks-nhsbsa.toml) config file into your project
 
 ```bash
-wget https://gitlab.com/nhsbsa/platform-services/gitleaks/nhsbsa-gitleaks/-/raw/main/nhsbsa-gitleaks.toml
+wget https://gitlab.com/nhsbsa/platform-services/gitleaks/gitleaks-nhsbsa/-/raw/main/gitleaks-nhsbsa.toml
 ```
 
 * Create a project specific `gitleaks.toml` file and configure it to extend the NHSBSA file

--- a/src/security/content-security-policy.md
+++ b/src/security/content-security-policy.md
@@ -324,7 +324,6 @@ Reference
 : Defines valid sources for request prefetch and prerendering, for example via the link tag with `rel="prefetch"` or `rel="prerender"`
 
   * <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src>
-  * <https://www.w3.org/TR/CSP/#directive-prefetch-src>
 
 Guidance
 : Use recommended value of `'none'`


### PR DESCRIPTION
Secrets detection `gitleaks-nhsbsa.toml` renamed
CSP directive `prefetch-src` removed from w3c guidance