### PR TITLE
chore(bug) review article list

### DIFF
--- a/lib/_javascripts/statusCollections.js
+++ b/lib/_javascripts/statusCollections.js
@@ -9,11 +9,12 @@ module.exports = (eleventyConfig) => {
   statuses.forEach((status) => {
     eleventyConfig.addCollection(status, function (collection) {
       return collection.getAll().filter((item) => {
-        if (item.data.status === status) {
-          console.log(status + ' status ' + item.data.title);
-          return true;
+        if (item.data.status === 'FINAL' && item.data.review?.requires_review) {
+          // Force the article collection from FINAL to REVIEW
+          item.data.status = 'REVIEW';
+          console.log(`status moved to REVIEW for ${item.data.title}`);
         }
-        return false;
+        return item.data.status === status;
       });
     });
   });

--- a/lib/tests/javascripts/statusCollections.test.js
+++ b/lib/tests/javascripts/statusCollections.test.js
@@ -46,7 +46,7 @@ describe('statusCollections callback', () => {
       ]),
   };
 
-  // mock console log
+  // spy on console log
   let consoleSpy;
   beforeEach(() => {
     consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -72,10 +72,11 @@ describe('statusCollections callback', () => {
       const result = callback(mockCollectionData);
 
       expect(mockCollectionData.getAll).toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalledWith(
-        `${status} status ${status} Article`
-      );
+      // expect(consoleSpy).toHaveBeenCalled();
+      // expect(consoleSpy).toHaveBeenCalledWith(
+      //   `${status} status ${status} Article`
+      // );
+      expect(consoleSpy).not.toHaveBeenCalled();
       expect(result).toEqual([
         { data: { status, title: `${status} Article` } },
       ]);
@@ -107,10 +108,11 @@ describe('statusCollections callback', () => {
       expect(mockCollectionDraftData.getAll).toHaveBeenCalled();
       // DRAFT status should return array of data
       if (status === 'DRAFT') {
-        expect(consoleSpy).toHaveBeenCalled();
-        expect(consoleSpy).toHaveBeenCalledWith(
-          `${status} status ${status} Article`
-        );
+        // expect(consoleSpy).toHaveBeenCalled();
+        // expect(consoleSpy).toHaveBeenCalledWith(
+        //   `${status} status ${status} Article`
+        // );
+        expect(consoleSpy).not.toHaveBeenCalled();
         expect(result).toEqual([
           { data: { status, title: `${status} Article` } },
           { data: { status, title: `${status} Article` } },
@@ -122,4 +124,32 @@ describe('statusCollections callback', () => {
       }
     }
   );
+
+  const mockCollectionDataWithReview = {
+    getAll: jest.fn().mockReturnValue([
+      {
+        data: {
+          status: 'FINAL',
+          title: 'FINAL Article',
+          review: { requires_review: true },
+        },
+      },
+    ]),
+  };
+
+  test('should update status to REVIEW when article requires_review and has FINAL status', () => {
+    const status = 'FINAL';
+    const foundCall = mockEleventyConfig.addCollection.mock.calls.find(
+      (call) => call[0] === status
+    );
+    expect(foundCall).toBeDefined();
+    const callback = foundCall[1];
+    callback(mockCollectionDataWithReview);
+
+    expect(mockCollectionDataWithReview.getAll).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      `status moved to REVIEW for FINAL Article`
+    );
+  });
 });


### PR DESCRIPTION
Changes:
 - Refactors `statusCollections` to check for `requires_review` allowing for articles with status = `REVIEW` and `FINAL` to be displayed if in need of a review.