### PR TITLE
Chore/release adoption schedule

### DIFF
--- a/src/_data/releaseAdoptionSchedule.yaml
+++ b/src/_data/releaseAdoptionSchedule.yaml
@@ -27,9 +27,11 @@ nodejs_aws_lambda:
   - version: v16
     release: 2022-05-11
     adopt: 2022-11-11
+    decommission: 2024-03-11
   - version: v14
     release: 2021-01-27
     adopt: 2021-07-27
+    decommission: 2023-11-27
   - version: v12
     release: 2019-11-18
     adopt: 2020-05-18

--- a/src/_data/releaseAdoptionSchedule.yaml
+++ b/src/_data/releaseAdoptionSchedule.yaml
@@ -54,6 +54,10 @@ java:
     adopt: 2015-09-01
     decommission: 2022-03-01
 spring_boot:
+  - version: 3.2.x
+    release: 2023-11-23
+    adopt: 2024-01-23
+    decommission: 2024-11-23
   - version: 3.1.x
     release: 2023-05-18
     adopt: 2023-07-18
@@ -99,28 +103,57 @@ spring_boot:
     adopt: 2017-03-30
     decommission: 2019-08-06
 spring_cloud:
-  - version: "2022.0"
-    release: 2022-12-01
-    adopt: 2023-12-01
-    decommission: 2025-12-01
-  - version: "2021.0"
+  - version: "2023.0 (Leyton)"
+    release: 2023-12-01
+    adopt: 2024-02-01
+    decommission: 2026-12-01
+  - version: "2022.0 (Kilburn)"
+    release: 2022-12-16
+    adopt: 2023-02-16
+    decommission: 2025-12-16
+  - version: "2021.0 (Jubilee)"
     release: 2021-12-01
     adopt: 2022-02-01
     decommission: 2024-12-01
-  - version: "2020.0"
+  - version: "2020.0 (ilford)"
     release: 2020-12-22
     adopt: 2021-02-22
     decommission: 2023-12-22
 java_aws_lambda:
-  - version: 17
+  - version: "17"
     release: 2023-04-27
     adopt: 2023-10-27
-  - version: 11
+  - version: "11"
     release: 2019-11-18
     adopt: 2020-05-18
-  - version: 8
+  - version: "8 (Amazon Linux 2)"
     release: 2015-06-01
     adopt: 2016-12-01
+  - version: "8 (Amazon Linux)"
+    release: 2015-06-01
+    adopt: 2016-12-01
+    decommission: 2023-12-31
+ruby:
+  - version: 3.3
+    release: 2023-12-25
+    adopt: 2024-06-25
+    decommission: 2027-03-31
+  - version: 3.2
+    release: 2022-12-25
+    adopt: 2023-06-25
+    decommission: 2026-03-31
+  - version: 3.1
+    release: 2021-12-25
+    adopt: 2022-06-25
+    decommission: 2025-03-31
+  - version: 3.0
+    release: 2020-12-25
+    adopt: 2021-06-25
+    decommission: 2024-03-31
+  - version: 2.7
+    release: 2019-12-25
+    adopt: 2020-06-25
+    decommission: 2023-03-31
 postgresql:
   - version: 15
     release: 2022-10-13

--- a/src/technologies/tech-release-adoption-schedule.md
+++ b/src/technologies/tech-release-adoption-schedule.md
@@ -80,7 +80,7 @@ __DECOMMISSION__
 AWS Lambdas run on platforms managed by Amazon. They publish release dates and a deprecation policy.
 
 * [AWS Lambda releases](https://docs.aws.amazon.com/lambda/latest/dg/lambda-releases.html)
-* [AWS Lambda runtime deprecation policy](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy)
+* [AWS Lambda runtime deprecation policy](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
 
 ::: card
 

--- a/src/technologies/tech-release-adoption-schedule.md
+++ b/src/technologies/tech-release-adoption-schedule.md
@@ -6,7 +6,7 @@ tags: tech
 order: 1
 status: FINAL
 review:
-    last_reviewed_date: 2023-05-06
+    last_reviewed_date: 2023-07-28
     review_cycle:
         month: 2
 issuesheet:
@@ -175,7 +175,7 @@ __DECOMMISSION__
 AWS Lambdas run on platforms managed by Amazon. They publish release dates and a deprecation policy.
 
 * [AWS Lambda releases](https://docs.aws.amazon.com/lambda/latest/dg/lambda-releases.html)
-* [AWS Lambda runtime deprecation policy](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy)
+* [AWS Lambda runtime deprecation policy](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
 
 ::: card
 
@@ -191,6 +191,34 @@ __DECOMMISSION__
 :::
 
 {{ schedule.appReleaseAdoptionSchedule('java_aws_lambda') }}
+
+## Ruby
+
+Ruby is a deprecated language for use in the NHSBSA. Existing projects using Ruby should maintain versions in accordance with this schedule.
+
+Ruby projects should use [rbenv](https://github.com/rbenv/rbenv) to manage Ruby versions.
+Include a `.ruby-version` file in the repository to specify the Ruby version in source code.
+
+::: details How we work out the adoption schedule for Ruby
+
+We follow the [Ruby release schedule](https://www.ruby-lang.org/en/downloads/releases/).
+
+Since Ruby 2.1, a new major version of Ruby has been released every year on December 25th, and EOLed 3 years, 3 months later.
+
+::: card
+
+__ASSESS__
+: on _release date_
+
+__ADOPT__
+: 6 months after _release date_
+
+__DECOMMISSION__
+: by _end of life date_
+
+:::
+
+{{ schedule.appReleaseAdoptionSchedule('ruby') }}
 
 ## PostgreSQL
 


### PR DESCRIPTION
review of adoption schedule
    
* lambda (node/java) deprecations added
* spring boot 3.2 added
* spring cloud 2023 nominal dates added
* ruby added