### PR TITLE
UR note taking guidance article

### DIFF
--- a/src/research/supporting-ur.md
+++ b/src/research/supporting-ur.md
@@ -1,0 +1,58 @@
+---
+layout: article
+title: "Observing and note taking in user research sessions "
+description: "How you can support by oberserving and note taking"
+tags: research
+order: 7
+---
+
+The below guidance has been written to help you support your user researcher through note taking during a user research session. This is a general overview of best practice, and any specific questions you have about note taking should be raised with the user researcher you are taking notes for. 
+
+While user researchers will be the ones to plan and run the research session, taking notes of what happens during the session is a key part of the process. It is helpful to have a dedicated note taker so the researcher can concentrate on listening to and responding to the user without having to look away to quickly write down or type notes. It also provides the researcher with accurate information to use as a basis for their analysis without having to go back through the whole recording.
+
+Prior to the research, your researcher will discuss with you what the purpose of the research is and clarify whether you are being asked to note take or observe. If you are note taking, they will let you know the sorts of observations they are looking for and will provide you with a template to follow so you have somewhere to write down your notes. This template will have a file name that correlates to a unique participant ID, so do not overwrite this.
+
+## What to expect
+
+Most research sessions last for approximately 60 minutes. Research sessions can vary in terms of the research method(s) used, so you may observe an interview, a usability test or a workshop for example.
+
+Prior to the research session you will have a discussion with your researcher where they will share the aims of the session with you. This will help you to understand the key areas you will note take or observe.
+
+Once your researcher has consent from the user that observers and notetakers can join the call, you will be invited to join the call. The researcher will introduce you to the participant when on the call. You can introduce yourself with the camera on or off. Depending on the aim of the UR session it may be better to introduce yourself as a ‘member of the team’ rather than your job role – for example, interaction designer, as this could impact how honest a participant's feedback is.
+
+Your researcher may open the floor to questions at the end of the session. This is your opportunity to ask any questions you may have. Please do not ask questions during the main session unless it is a co-design session as this can confuse users.
+
+If appropriate you may have a wash up call with your researcher following the session to discuss outcomes and key observations.
+
+## Note-taking
+
+When you are note taking you are looking to write down observations. These should be based in fact, rather than your interpretation of what has happened. When looking for observations, you could write down things such as:
+
+- things people do - like processes, tasks, tools, problems and barriers
+- how they think - including their goals, triggers, choices, reasons, knowledge and gaps
+- how they feel - for example, their motivations, reactions, fears and frustrations
+
+For example, observations include:
+
+- “the user prefers to ask friends and family to help them search online about whether they are eligible for a pre-payment certificate”
+- “User was able to navigate to ‘save and continue button’ with no issues”
+- “After submitting claim, user was anxious about whether their claim would be picked up from the BSA or forgotten about”
+- “User finds the current paper process time-consuming"
+
+Do not add your interpretations to your notes, as analysis will take place after the research sessions have finished.
+
+When writing observations, you do not have to write out word for word what the user is saying. Notes are primarily used for analysis, so writing things out based on single observations at a time is more beneficial. Writing in a bullet point format could be useful to help you note-take in a brief, but clear way.
+
+Avoid writing any personal identifiable information in your notes, such as their name or where they work. For example, if they mention that they work in the Royal Victoria Infirmary Hospital, you can note that they work in a hospital.
+
+Use the template your note taker has provided to structure your notes. You will receive a new template every time you note take. If you are taking notes across multiple sessions, use the new template each time rather than adding them all to one document.
+
+Your template may be structured broadly by theme (for example, “background information” and “current processes”), or may be structured by screens (for example, “start page”, “check your answers”). Try to write your notes underneath the relevant sections as closely as possible.
+
+Sometimes, the user might begin speaking about something that does not appear directly relevant to the section you have been writing in. In this instance, just continue note-taking wherever you have been, as it is more important to capture the observations than spend time working out where they best fit.
+
+## When the research session has finished
+
+Once the session has finished, save the file. Do not overwrite the file name your researcher has provided, as this links to a unique participant ID that is used for all data related to this user. Share this with your researcher via Slack, Teams or email, and delete it off your machine.
+
+You do not need to add this to SharePoint, as your researcher has set processes to follow to ensure the data is handled and stored appropriately.

--- a/src/research/supporting-ur.md
+++ b/src/research/supporting-ur.md
@@ -1,7 +1,7 @@
 ---
 layout: article
 title: "Observing and note taking in user research sessions "
-description: "How you can support by oberserving and note taking"
+description: "How you can support by observing and note taking"
 tags: research
 order: 7
 ---


### PR DESCRIPTION
Article for giving guidance to someone who wants to observe or do note taking for the user researcher.

This is currently a direct link to the article within the UR space.

This is not sitting within Tools and resources due to questions of whether we would include this there as it is not directed to the UR and more other roles, so the potential to include a new category of supporting to the UR later down the line.