### PR TITLE
chore - Add cross-env for better compatibility across devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": "^9.9.0",
         "@nhsbsa/cookie-consent-component": "0.0.6",
+        "cross-env": "^7.0.3",
         "eleventy-auto-cache-buster": "^0.6.0",
         "eleventy-plugin-dart-sass": "^1.0.3",
         "eleventy-plugin-external-links": "^1.1.2",
@@ -2682,6 +2683,24 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   },
   "scripts": {
     "start": "npx @11ty/eleventy --serve --pathprefix 'nhsbsa-digital-playbook'",
-    "build": "env NODE_ENV=production npx eleventy --pathprefix 'nhsbsa-digital-playbook'",
-    "test": "NODE_ENV=test jest",
-    "test:eslint": "NODE_ENV=test npx eslint .",
-    "test:eslint-fix": "NODE_ENV=test npx eslint . --fix",
-    "test:coverage": "NODE_ENV=test jest --coverage"
+    "build": "cross-env NODE_ENV=production npx eleventy --pathprefix 'nhsbsa-digital-playbook'",
+    "test": "cross-env NODE_ENV=test jest",
+    "test:eslint": "cross-env NODE_ENV=test npx eslint .",
+    "test:eslint-fix": "cross-env NODE_ENV=test npx eslint . --fix",
+    "test:coverage": "cross-env NODE_ENV=test jest --coverage"
   },
   "repository": {
     "type": "git",
@@ -31,6 +31,7 @@
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.9.0",
     "@nhsbsa/cookie-consent-component": "0.0.6",
+    "cross-env": "^7.0.3",
     "eleventy-auto-cache-buster": "^0.6.0",
     "eleventy-plugin-dart-sass": "^1.0.3",
     "eleventy-plugin-external-links": "^1.1.2",


### PR DESCRIPTION
Windows users unable to run npm commands due to compatibility issues with environment flags, adding cross-env package resolves this. 