### PR TITLE
schedule changes

### DIFF
--- a/src/_data/releaseAdoptionSchedule.yaml
+++ b/src/_data/releaseAdoptionSchedule.yaml
@@ -158,7 +158,7 @@ spring_cloud:
     decommission: 2028-11-25
   - version: "2025.0 (Northfields)"
     release: 2025-05-29
-    adopt: 2026-07-29
+    adopt: 2025-07-29
     decommission: 2028-05-29
   - version: "2024.0 (Moorgate)"
     release: 2024-12-05
@@ -183,7 +183,7 @@ spring_cloud:
 java_aws_lambda:
   - version: "25"
     release: 2025-11-16
-    adopt: 2024-05-16
+    adopt: 2026-05-16
     decommission: 2029-06-30
   - version: "21"
     release: 2023-11-16
@@ -206,31 +206,31 @@ java_aws_lambda:
     adopt: 2016-12-01
     decommission: 2024-02-08
 ruby:
-  - version: 4.0
+  - version: "4.0"
     release: 2025-12-25
     adopt: 2026-06-25
     decommission: 2029-03-31
-  - version: 3.4
+  - version: "3.4"
     release: 2024-12-25
     adopt: 2025-06-25
     decommission: 2028-03-31
-  - version: 3.3
+  - version: "3.3"
     release: 2023-12-25
     adopt: 2024-06-25
     decommission: 2027-03-31
-  - version: 3.2
+  - version: "3.2"
     release: 2022-12-25
     adopt: 2023-06-25
     decommission: 2026-03-31
-  - version: 3.1
+  - version: "3.1"
     release: 2021-12-25
     adopt: 2022-06-25
     decommission: 2025-03-31
-  - version: 3.0
+  - version: "3.0"
     release: 2020-12-25
     adopt: 2021-06-25
     decommission: 2024-03-31
-  - version: 2.7
+  - version: "2.7"
     release: 2019-12-25
     adopt: 2020-06-25
     decommission: 2023-03-31


### PR DESCRIPTION
node lambda v24 & v26
spring cloud 2025.1 Oakwood
java lambda v25
java lambda deprecation dates announced
ruby 4.0