### PR TITLE
Move the "User research training" page into the UR section

### DIFF
--- a/src/research/user-research-community.md
+++ b/src/research/user-research-community.md
@@ -1,0 +1,54 @@
+---
+layout: article
+title: "User research community"
+description: "Connect and learn with your peers"
+tags: research
+order: 15
+---
+
+## UR Community meetings
+
+UR Community meetings take place every two weeks on a Thursday from 2pm to 3pm. They’re open to the entire research community. These sessions are led by the community, for the community, and cover a wide range of topics.
+
+You could use a session to:
+
+* share an update on a project you're working on
+* present a research method or approach you've recently used
+* discuss work from a previous role or organisation
+* run a short training or knowledge-sharing session
+
+If there's a topic you'd like to discuss, you can sign up for a session on the UR Community schedule.
+
+Everyone is encouraged to lead community sessions, either on their own or with colleagues. We also welcome guest speakers from academia, private sector organisations, other government departments and training providers.
+
+If you’d like to invite colleagues from the wider UCD Community to your session, you should contact the UR leads.
+You should be added to the UR Community invite during onboarding. If you do not receive the invite, contact the UR leads.
+
+All sessions are recorded. If you miss a session, you can find the recordings in the Community sessions folder.
+
+## UCD newsletters
+
+The senior UCD team produces a quarterly newsletter using contributions from across the UCD Community.
+
+The newsletter is shared across DDaT by email and highlights:
+
+* team achievements
+* important project milestones
+* new UCD starters
+* community news and updates
+
+We welcome ideas for future content. Share any suggestions with the senior UCD team.
+
+## Away days
+
+The UCD team meets once a year for an away day. Volunteers from across the UCD community plan this event. 
+
+Away days give you the opportunity to:
+
+* spend time with colleagues in person 
+* strengthen relationships across the profession
+* take part in team activities
+
+The head of profession for user-centred design will share details of the location, date and agenda before the event.
+
+Your people manager can provide guidance and support if you need to book travel.

--- a/src/research/user-research-training.md
+++ b/src/research/user-research-training.md
@@ -2,8 +2,8 @@
 layout: article
 title: "User research training"
 description: "Opportunities for the user research community"
-tags: training
-order: 3
+tags: research
+order: 15
 ---
 
 The UCD Leadership Team regularly shares training opportunities for the user research community.


### PR DESCRIPTION
Move the "User research training" page into the UR section
Add the word doc content into the UR section as "User research community"